### PR TITLE
Integrate shadcn UI via CDN and overhaul dashboard layout

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,54 +1,77 @@
 /* Custom styles for the chat app */
+
+:root {
+  --text-color: #000000;
+  --background-color: #FFFFFF;
+  --accent-color: #C7FF00;
+  --card-color: #F5F7F9;
+  --muted-color: #6B7280;
+  --radius-lg: 24px;
+  --transition-fast: 200ms;
+}
+
+body {
+  background: var(--background-color);
+  color: var(--text-color);
+  font-family: 'Inter', system-ui, sans-serif;
+}
 .navbar {
-    box-shadow: 0 2px 4px rgba(0,0,0,.1);
+  background: var(--background-color);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .display-4 {
-    font-weight: 600;
-    color: #2c3e50;
+  font-weight: 700;
+  color: var(--text-color);
 }
 
 .lead {
-    color: #7f8c8d;
+  color: var(--muted-color);
 }
 
 .card {
-    border: none;
-    box-shadow: 0 2px 4px rgba(0,0,0,.05);
-    transition: transform 0.2s;
+  border: none;
+  background: var(--card-color);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  transition: transform var(--transition-fast), opacity var(--transition-fast);
 }
 
 .card:hover {
-    transform: translateY(-5px);
+  transform: translateY(-5px);
 }
 
 .card-title {
-    color: #2c3e50;
-    font-weight: 600;
+  color: var(--text-color);
+  font-weight: 700;
 }
 
 .btn-primary {
-    background-color: #3498db;
-    border-color: #3498db;
+  background-color: var(--accent-color);
+  border-color: var(--accent-color);
+  color: var(--text-color);
+  border-radius: var(--radius-lg);
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
 }
 
 .btn-primary:hover {
-    background-color: #2980b9;
-    border-color: #2980b9;
+  opacity: 0.85;
+  transform: scale(0.98);
 }
 
 .btn-outline-primary {
-    color: #3498db;
-    border-color: #3498db;
+  color: var(--accent-color);
+  border-color: var(--accent-color);
+  border-radius: var(--radius-lg);
 }
 
 .btn-outline-primary:hover {
-    background-color: #3498db;
-    border-color: #3498db;
+  background-color: var(--accent-color);
+  color: var(--text-color);
 }
 
 footer {
-    margin-top: 100px;
+  margin-top: 100px;
 }
 
 /* Responsive adjustments */
@@ -63,9 +86,9 @@ footer {
 }
 
 #conversationsList .chat-preview.active {
-  background: #e6f0ff !important;
-  border-left: 4px solid #007bff !important;
-  box-shadow: 0 2px 8px rgba(0,123,255,0.08);
+  background: var(--card-color) !important;
+  border-left: 4px solid var(--accent-color) !important;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
 }
 
 #conversationsList .chat-preview.active.unread-preview {
@@ -73,12 +96,12 @@ footer {
 }
 
 .chat-preview.unread-preview {
-  background: #f0f6ff;
+  background: var(--card-color);
 }
 
 .unread-message {
   font-weight: bold;
-  color: #222;
+  color: var(--text-color);
 }
 
 /* Add Business Form Styles */
@@ -87,11 +110,11 @@ footer {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f7fafd;
+  background: var(--card-color);
 }
 .add-business-card {
-  background: #fff;
-  border-radius: 12px;
+  background: var(--background-color);
+  border-radius: var(--radius-lg);
   box-shadow: 0 4px 24px rgba(0,0,0,0.08);
   padding: 2.5rem 2rem 2rem 2rem;
   max-width: 400px;
@@ -100,7 +123,7 @@ footer {
 .add-business-card h2 {
   font-size: 2rem;
   font-weight: 700;
-  color: #2c3e50;
+  color: var(--text-color);
   margin-bottom: 1.5rem;
   text-align: center;
 }
@@ -110,39 +133,41 @@ footer {
 }
 .add-business-card label {
   font-weight: 500;
-  color: #34495e;
+  color: var(--text-color);
   margin-bottom: 0.5rem;
 }
 .add-business-card input[type="text"] {
-  border-radius: 6px;
-  border: 1px solid #dbeafe;
-  padding: 1rem 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--muted-color);
+  padding: 1rem;
   font-size: 1.1rem;
   margin-bottom: 1.5rem;
   width: 100%;
-  transition: border 0.2s;
+  transition: border var(--transition-fast), box-shadow var(--transition-fast);
   box-sizing: border-box;
 }
 .add-business-card input[type="text"]:focus {
-  border-color: #3498db;
+  border-color: var(--accent-color);
   outline: none;
+  box-shadow: 0 0 0 2px var(--accent-color);
 }
 .add-business-card button {
-  background: #3498db;
-  color: #fff;
+  background: var(--accent-color);
+  color: var(--text-color);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   padding: 0.9rem 1rem;
   font-size: 1.1rem;
   font-weight: 600;
   width: 100%;
-  transition: background 0.2s;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
   margin-top: 0.5rem;
   letter-spacing: 0.5px;
   text-align: center;
 }
 .add-business-card button:hover {
-  background: #217dbb;
+  opacity: 0.85;
+  transform: scale(0.98);
 }
 
 body, input, button, select, textarea, h1, h2, h3, h4, h5, h6 {

--- a/views/add_business.ejs
+++ b/views/add_business.ejs
@@ -6,11 +6,24 @@
   <title>Create Your Business</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: { accent: '#C7FF00', card: '#F5F7F9', muted: '#6B7280', text: '#000000', background: '#FFFFFF' },
+          borderRadius: { lg: '24px' }
+        }
+      }
+    }
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shadcn/ui@latest/dist/style.css">
+  <link href="/css/style.css" rel="stylesheet">
   <style>
     html, body { height: 100%; min-height: 100vh; }
     body {
       min-height: 100vh;
-      background: linear-gradient(135deg, #2563eb 0%, #22c55e 100%);
+      background: var(--background-color);
       font-family: 'Inter', system-ui, sans-serif;
       display: flex;
       flex-direction: column;
@@ -75,24 +88,25 @@
       transition: border 0.18s, box-shadow 0.18s;
     }
     input[type="text"]:focus {
-      border-color: #2563eb;
-      box-shadow: 0 0 0 2px #2563eb22;
+      border-color: var(--accent-color);
+      box-shadow: 0 0 0 2px var(--accent-color);
       outline: none;
     }
     button[type="submit"] {
-      background: linear-gradient(90deg, #2563eb 0%, #22c55e 100%);
-      color: #fff;
+      background: var(--accent-color);
+      color: var(--text-color);
       font-weight: 600;
       border: none;
-      border-radius: 24px;
+      border-radius: var(--radius-lg);
       padding: 12px 0;
       font-size: 1.1rem;
       margin-top: 0.5rem;
-      transition: background 0.18s;
-      box-shadow: 0 2px 8px rgba(59,130,246,0.08);
+      transition: opacity var(--transition-fast), transform var(--transition-fast);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
     }
     button[type="submit"]:hover {
-      background: #2563eb;
+      opacity: 0.85;
+      transform: scale(0.98);
     }
     @media (max-width: 600px) {
       .add-business-card {

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -5,13 +5,35 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Botbuilders Chat Dashboard</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        accent: '#C7FF00',
+                        card: '#F5F7F9',
+                        muted: '#6B7280',
+                        text: '#000000',
+                        background: '#FFFFFF'
+                    },
+                    borderRadius: {
+                        lg: '24px'
+                    }
+                }
+            }
+        }
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shadcn/ui@latest/dist/style.css">
+    <link href="/css/style.css" rel="stylesheet">
     <style>
         html, body { height: 100%; min-height: 100vh; }
-        body { min-height: 100vh; background: linear-gradient(135deg, #f6f8fa 0%, #e0e7ff 100%); height: 100vh; overflow: hidden; }
+        body { min-height: 100vh; background: var(--background-color); height: 100vh; overflow: hidden; }
         .dashboard-header {
             box-shadow: 0 2px 8px rgba(0,0,0,0.04);
-            background: linear-gradient(90deg, #2563eb 0%, #22c55e 100%);
+            background: var(--card-color);
             border-bottom: none;
         }
         .dashboard-header .logo-img {
@@ -32,7 +54,7 @@
         }
         .sidebar-nav { margin-top: 2rem; }
         .sidebar-nav .nav-link {
-            color: #2563eb;
+            color: var(--accent-color);
             border-radius: 10px;
             font-weight: 500;
             margin-bottom: 8px;
@@ -45,8 +67,8 @@
         }
         .sidebar-nav .nav-link i { font-size: 1.2rem; }
         .sidebar-nav .nav-link.active {
-            background: linear-gradient(90deg, #2563eb 0%, #22c55e 100%);
-            color: #fff;
+            background: var(--accent-color);
+            color: var(--text-color);
             font-weight: 700;
             box-shadow: 0 2px 8px rgba(59,130,246,0.08);
         }
@@ -141,8 +163,8 @@
         }
         .message.bot {
             align-self: flex-end;
-            background: #2563eb;
-            color: #fff;
+            background: var(--accent-color);
+            color: var(--text-color);
             border-bottom-right-radius: 6px;
             margin-left: auto;
         }
@@ -157,15 +179,15 @@
             width: 36px;
             height: 36px;
             border-radius: 50%;
-            background: #e0e7ff;
+            background: var(--card-color);
             display: flex;
             align-items: center;
             justify-content: center;
             font-size: 1.3rem;
             font-weight: 700;
-            color: #2563eb;
+            color: var(--accent-color);
         }
-        .message.bot .message-avatar { background: #2563eb; color: #fff; }
+        .message.bot .message-avatar { background: var(--accent-color); color: var(--text-color); }
         .message.agent .message-avatar { background: #22c55e; color: #fff; }
         .message.user .message-avatar { background: #f0f0f0; color: #2563eb; }
         .chat-input-area {
@@ -191,12 +213,12 @@
         }
         #messageInput:focus {
             outline: none;
-            border-color: #2563eb;
-            box-shadow: 0 0 0 0.2rem #2563eb33;
+            border-color: var(--accent-color);
+            box-shadow: 0 0 0 0.2rem var(--accent-color);
         }
         .send-btn {
-            color: #fff;
-            background: #2563eb;
+            color: var(--text-color);
+            background: var(--accent-color);
             border: none;
             border-radius: 50%;
             width: 48px;
@@ -205,10 +227,11 @@
             align-items: center;
             justify-content: center;
             font-size: 1.3rem;
-            transition: background 0.18s;
+            transition: opacity var(--transition-fast), transform var(--transition-fast);
         }
         .send-btn:hover {
-            background: #2563eb;
+            opacity: 0.85;
+            transform: scale(0.98);
         }
         .status-badge {
             padding: 2px 10px;
@@ -256,28 +279,29 @@
             transition: border 0.18s, box-shadow 0.18s;
         }
         .form-control:focus, .form-select:focus {
-            border-color: #2563eb;
-            box-shadow: 0 0 0 2px #2563eb22;
+            border-color: var(--accent-color);
+            box-shadow: 0 0 0 2px var(--accent-color);
         }
         .btn-primary {
-            background: #2563eb;
-            border-color: #2563eb;
+            background: var(--accent-color);
+            border-color: var(--accent-color);
+            color: var(--text-color);
             font-weight: 600;
-            border-radius: 8px;
-            transition: background 0.18s, border 0.18s;
+            border-radius: var(--radius-lg);
+            transition: opacity var(--transition-fast), transform var(--transition-fast);
         }
         .btn-primary:hover {
-            background: #1d4ed8;
-            border-color: #1d4ed8;
+            opacity: 0.85;
+            transform: scale(0.98);
         }
         .btn-outline-primary {
-            color: #2563eb;
-            border-color: #2563eb;
-            border-radius: 8px;
+            color: var(--accent-color);
+            border-color: var(--accent-color);
+            border-radius: var(--radius-lg);
         }
         .btn-outline-primary:hover {
-            background: #2563eb;
-            color: #fff;
+            background: var(--accent-color);
+            color: var(--text-color);
         }
         .btn-outline-danger {
             border-radius: 8px;
@@ -341,38 +365,36 @@
 </head>
 <body>
     <!-- Dashboard Header -->
-    <header class="dashboard-header d-flex align-items-center px-4 py-3 border-bottom justify-content-between" style="height: 72px;">
+    <header class="dashboard-header flex items-center justify-between px-6 py-4 shadow bg-card" style="height:72px;">
         <img src="/images/BotBuilders_Logo_White_2.png" alt="Logo" class="logo-img">
-        <div class="form-check form-switch ms-2">
+        <label class="inline-flex items-center gap-2 text-sm font-medium">
             <input class="form-check-input" type="checkbox" id="notificationToggle">
-            <label class="form-check-label text-white" for="notificationToggle">Notification Sound</label>
-        </div>
+            Notification Sound
+        </label>
     </header>
-    <div class="dashboard-root">
+    <div class="dashboard-root flex">
         <!-- Sidebar Navigation -->
-        <div class="sidebar col-12 col-md-3 p-0 d-flex flex-column">
-            <div class="p-3 border-bottom bg-white d-flex align-items-center justify-content-between">
-                <div>
-                    <h5 class="mb-0">Your Businesses</h5>
-                    <select id="businessSelector" class="form-select mt-2">
+        <aside class="sidebar w-64 flex-shrink-0 bg-white border-r flex flex-col">
+            <div class="p-4 border-b">
+                <h5 class="mb-2 fw-bold">Your Businesses</h5>
+                <select id="businessSelector" class="form-select mt-2">
                         <% businesses.forEach(function(biz) { %>
                             <option value="<%= biz.id %>" <%= biz.id === selectedBusiness.id ? 'selected' : '' %>><%= biz.name %></option>
                         <% }); %>
                     </select>
-                </div>
             </div>
-            <nav class="sidebar-nav nav flex-column nav-pills p-2 gap-2">
-                <a class="nav-link active" id="tab-chats" href="#" data-tab="chats"><i class="fas fa-comments me-2"></i>Chats</a>
-                <a class="nav-link" id="tab-team" href="#" data-tab="team"><i class="fas fa-users me-2"></i>Team Members</a>
-                <a class="nav-link" id="tab-widget" href="#" data-tab="widget"><i class="fas fa-cog me-2"></i>Widget Settings</a>
-                <a class="nav-link" id="tab-ai" href="#" data-tab="ai"><i class="fas fa-robot me-2"></i>AI Settings</a>
-                <a class="nav-link" id="tab-training" href="#" data-tab="training"><i class="fas fa-graduation-cap me-2"></i>AI Training Info</a>
-                <a class="nav-link" id="tab-install" href="#" data-tab="install"><i class="fas fa-code me-2"></i>Install Widget</a>
-                <a class="nav-link mt-auto text-danger" href="/logout"><i class="fas fa-sign-out-alt me-2"></i>Logout</a>
+            <nav class="sidebar-nav nav flex-column nav-pills p-3 gap-2 flex-1 overflow-y-auto">
+                <a class="nav-link active flex items-center gap-2" id="tab-chats" href="#" data-tab="chats"><i class="fas fa-comments"></i><span>Chats</span></a>
+                <a class="nav-link flex items-center gap-2" id="tab-team" href="#" data-tab="team"><i class="fas fa-users"></i><span>Team Members</span></a>
+                <a class="nav-link flex items-center gap-2" id="tab-widget" href="#" data-tab="widget"><i class="fas fa-cog"></i><span>Widget Settings</span></a>
+                <a class="nav-link flex items-center gap-2" id="tab-ai" href="#" data-tab="ai"><i class="fas fa-robot"></i><span>AI Settings</span></a>
+                <a class="nav-link flex items-center gap-2" id="tab-training" href="#" data-tab="training"><i class="fas fa-graduation-cap"></i><span>AI Training Info</span></a>
+                <a class="nav-link flex items-center gap-2" id="tab-install" href="#" data-tab="install"><i class="fas fa-code"></i><span>Install Widget</span></a>
+                <a class="nav-link mt-auto text-danger flex items-center gap-2" href="/logout"><i class="fas fa-sign-out-alt"></i><span>Logout</span></a>
             </nav>
-        </div>
+        </aside>
         <!-- Main Content Area -->
-        <div class="main-content col-12 col-md-9 p-0">
+        <div class="main-content flex-1 p-0">
             <!-- Chats Section -->
             <section id="section-chats" class="tab-section active">
                 <div class="chat-area">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -5,16 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BotBuilders - AI Chatbot SaaS</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { accent: '#C7FF00', card: '#F5F7F9', muted: '#6B7280', text: '#000000', background: '#FFFFFF' },
+                    borderRadius: { lg: '24px' }
+                }
+            }
+        }
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shadcn/ui@latest/dist/style.css">
     <link href="/css/style.css" rel="stylesheet">
     <script src="https://kit.fontawesome.com/7b2b2a2e8b.js" crossorigin="anonymous"></script>
     <style>
         body {
-            background: linear-gradient(135deg, #f6f8fa 0%, #e0e7ff 100%);
+            background: var(--background-color);
             min-height: 100vh;
         }
         .navbar {
-            background: #fff !important;
-            box-shadow: 0 2px 12px rgba(59,130,246,0.06);
+            background: var(--background-color) !important;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.06);
         }
         .navbar-brand img {
             height: 40px;
@@ -23,10 +36,10 @@
         }
         .hero-section {
             padding: 140px 0 100px 0;
-            background: linear-gradient(120deg, #2563eb 0%, #22c55e 100%);
-            color: #fff;
-            border-radius: 0 0 48px 48px;
-            box-shadow: 0 8px 32px rgba(59,130,246,0.10);
+            background: var(--card-color);
+            color: var(--text-color);
+            border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+            box-shadow: 0 8px 32px rgba(0,0,0,0.10);
         }
         .hero-title {
             font-size: 3rem;
@@ -38,14 +51,15 @@
             font-size: 1.5rem;
             font-weight: 400;
             margin-bottom: 32px;
-            color: #e0e7ff;
+            color: var(--muted-color);
         }
         .hero-cta {
             font-size: 1.25rem;
             padding: 14px 36px;
-            border-radius: 32px;
+            border-radius: var(--radius-lg);
             font-weight: 700;
-            box-shadow: 0 2px 8px rgba(59,130,246,0.10);
+            box-shadow: 0 2px 8px rgba(0,0,0,0.10);
+            transition: opacity var(--transition-fast), transform var(--transition-fast);
         }
         .hero-img {
             max-width: 420px;
@@ -57,15 +71,15 @@
         }
         .feature-card {
             border: none;
-            border-radius: 18px;
-            box-shadow: 0 2px 16px rgba(59,130,246,0.08);
-            transition: transform 0.18s, box-shadow 0.18s;
-            background: #fff;
+            border-radius: var(--radius-lg);
+            box-shadow: 0 2px 16px rgba(0,0,0,0.08);
+            transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+            background: var(--card-color);
             margin-bottom: 32px;
         }
         .feature-card:hover {
             transform: translateY(-6px) scale(1.03);
-            box-shadow: 0 8px 32px rgba(59,130,246,0.12);
+            box-shadow: 0 8px 32px rgba(0,0,0,0.12);
         }
         .feature-icon {
             font-size: 3.2rem;
@@ -82,13 +96,13 @@
             margin-bottom: 10px;
         }
         .feature-desc {
-            color: #555;
+            color: var(--muted-color);
         }
         .footer {
-            background: #222;
-            color: #fff;
+            background: var(--card-color);
+            color: var(--text-color);
             padding: 40px 0 20px 0;
-            border-radius: 32px 32px 0 0;
+            border-radius: var(--radius-lg) var(--radius-lg) 0 0;
             margin-top: 60px;
         }
         .footer-logo {
@@ -96,12 +110,12 @@
             margin-bottom: 12px;
         }
         .footer-link {
-            color: #e0e7ff;
+            color: var(--muted-color);
             text-decoration: none;
             margin-right: 18px;
         }
         .footer-link:hover {
-            color: #22c55e;
+            color: var(--accent-color);
         }
     </style>
 </head>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -5,46 +5,60 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login - BotBuilders</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { accent: '#C7FF00', card: '#F5F7F9', muted: '#6B7280', text: '#000000', background: '#FFFFFF' },
+                    borderRadius: { lg: '24px' }
+                }
+            }
+        }
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shadcn/ui@latest/dist/style.css">
     <link href="/css/style.css" rel="stylesheet">
     <style>
         body {
-            background: linear-gradient(135deg, #f6f8fa 0%, #e0e7ff 100%);
+            background: var(--background-color);
             min-height: 100vh;
         }
         .navbar {
-            background: #fff !important;
-            box-shadow: 0 2px 12px rgba(59,130,246,0.06);
+            background: var(--background-color) !important;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.06);
         }
         .navbar-brand img {
             height: 40px;
             width: auto;
         }
         .auth-card {
-            border-radius: 18px;
-            box-shadow: 0 2px 16px rgba(59,130,246,0.08);
-            background: #fff;
+            border-radius: var(--radius-lg);
+            box-shadow: 0 2px 16px rgba(0,0,0,0.08);
+            background: var(--card-color);
             padding: 2.5rem 2rem;
         }
         .btn-primary {
-            background: #2563eb;
-            border-color: #2563eb;
+            background: var(--accent-color);
+            border-color: var(--accent-color);
+            color: var(--text-color);
             font-weight: 600;
-            border-radius: 8px;
-            transition: background 0.18s, border 0.18s;
+            border-radius: var(--radius-lg);
+            transition: opacity var(--transition-fast), transform var(--transition-fast);
         }
         .btn-primary:hover {
-            background: #1d4ed8;
-            border-color: #1d4ed8;
+            opacity: 0.85;
+            transform: scale(0.98);
         }
         .form-label {
             font-weight: 500;
         }
         .auth-link {
-            color: #2563eb;
+            color: var(--accent-color);
             text-decoration: none;
         }
         .auth-link:hover {
-            color: #22c55e;
+            color: var(--text-color);
             text-decoration: underline;
         }
     </style>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -5,46 +5,60 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Register - BotBuilders</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: { accent: '#C7FF00', card: '#F5F7F9', muted: '#6B7280', text: '#000000', background: '#FFFFFF' },
+                    borderRadius: { lg: '24px' }
+                }
+            }
+        }
+    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shadcn/ui@latest/dist/style.css">
     <link href="/css/style.css" rel="stylesheet">
     <style>
         body {
-            background: linear-gradient(135deg, #f6f8fa 0%, #e0e7ff 100%);
+            background: var(--background-color);
             min-height: 100vh;
         }
         .navbar {
-            background: #fff !important;
-            box-shadow: 0 2px 12px rgba(59,130,246,0.06);
+            background: var(--background-color) !important;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.06);
         }
         .navbar-brand img {
             height: 40px;
             width: auto;
         }
         .auth-card {
-            border-radius: 18px;
-            box-shadow: 0 2px 16px rgba(59,130,246,0.08);
-            background: #fff;
+            border-radius: var(--radius-lg);
+            box-shadow: 0 2px 16px rgba(0,0,0,0.08);
+            background: var(--card-color);
             padding: 2.5rem 2rem;
         }
         .btn-primary {
-            background: #2563eb;
-            border-color: #2563eb;
+            background: var(--accent-color);
+            border-color: var(--accent-color);
+            color: var(--text-color);
             font-weight: 600;
-            border-radius: 8px;
-            transition: background 0.18s, border 0.18s;
+            border-radius: var(--radius-lg);
+            transition: opacity var(--transition-fast), transform var(--transition-fast);
         }
         .btn-primary:hover {
-            background: #1d4ed8;
-            border-color: #1d4ed8;
+            opacity: 0.85;
+            transform: scale(0.98);
         }
         .form-label {
             font-weight: 500;
         }
         .auth-link {
-            color: #2563eb;
+            color: var(--accent-color);
             text-decoration: none;
         }
         .auth-link:hover {
-            color: #22c55e;
+            color: var(--text-color);
             text-decoration: underline;
         }
     </style>


### PR DESCRIPTION
## Summary
- add Tailwind and shadcn/ui CDN links with palette config
- restyle dashboard header and sidebar with new Tailwind classes
- include Tailwind/shadcn on auth and landing pages

## Testing
- `npm test` *(fails: Error: no test specified)*